### PR TITLE
Fixed the build pipeline after the PR for M1 chip support

### DIFF
--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -20,6 +20,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        
+      - name: Install buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: latest
 
       # https://github.com/actions/checkout#Fetch-all-tags
       - name: Fetch tags


### PR DESCRIPTION
The previous pull request #5 for adding support for M1 chips was missing a dependency for the pipeline to setup buildx properly for the Github pipeline. The author of the previous PR and I tested this in a fork and our pipelines passed the build step successfully