### PR TITLE
Added support for multi-platform images take two

### DIFF
--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -7,6 +7,10 @@ on:
     # every 12 hours
     - cron: '0 */12 * * *'
 
+    
+env:
+  DOCKER_DEFAULT_PLATFORM: linux/amd64
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -20,12 +24,18 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        
+      - name: Install buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: latest
 
       # https://github.com/actions/checkout#Fetch-all-tags
       - name: Fetch tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
-      - name: Get version
+      - name: Get version (browser)
         id: get_version
         run: echo ::set-output name=result::$(make --file ${{ matrix.package }}/Makefile get-version)
 
@@ -39,9 +49,19 @@ jobs:
           echo version: ${{ steps.get_version.outputs.result }}
           echo status: ${{ steps.check_status.outputs.result }}
 
-      - name: Build image
+      - name: Docker GitHub Packages login
         if: steps.check_status.outputs.result == 'outdated'
-        run: make --file ${{ matrix.package }}/Makefile build version=${{ steps.get_version.outputs.result }}
+        # TODO: Change this back DOCKER_DEPLOYER to GITHUB_TOKEN
+        run: echo ${{ secrets.DOCKER_DEPLOYER }} | docker login --username ${{ github.actor }} --password-stdin docker.pkg.github.com
+      
+      - name: Docker Hub login
+        if: steps.check_status.outputs.result == 'outdated'
+        run: echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login --username nextoolsbot --password-stdin
+
+      - name: Build image (push)
+        if: steps.check_status.outputs.result == 'outdated'
+        id: build
+        run: echo ::set-output name=result::$(make --file ${{ matrix.package }}/Makefile build version=${{ steps.get_version.outputs.result }})
 
       - name: Test
         if: steps.check_status.outputs.result == 'outdated'
@@ -51,6 +71,7 @@ jobs:
         id: get_size
         if: steps.check_status.outputs.result == 'outdated'
         run: |
+          docker pull ${{ steps.build.outputs.result }}
           docker save ${{ matrix.package }} | gzip > ${{ matrix.package }}.tar.gz
           echo ::set-output name=result::$(du --human-readable --apparent-size ${{ matrix.package }}.tar.gz | cut --fields=1)
           rm ${{ matrix.package }}.tar.gz
@@ -83,19 +104,3 @@ jobs:
       - name: Git push
         if: steps.check_status.outputs.result == 'outdated'
         run: git push --force --tags origin master
-
-      - name: Docker GitHub Packages login
-        if: steps.check_status.outputs.result == 'outdated'
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login --username ${{ github.actor }} --password-stdin docker.pkg.github.com
-
-      - name: Docker GitHub Packages push
-        if: steps.check_status.outputs.result == 'outdated'
-        run: docker push docker.pkg.github.com/nextools/images/${{ matrix.package }}
-
-      - name: Docker Hub login
-        if: steps.check_status.outputs.result == 'outdated'
-        run: echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login --username nextoolsbot --password-stdin
-
-      - name: Docker Hub push
-        if: steps.check_status.outputs.result == 'outdated'
-        run: docker push nextools/${{ matrix.package }}

--- a/chromium/Makefile
+++ b/chromium/Makefile
@@ -2,6 +2,9 @@
 
 CURRENT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+IMAGE_NAME="docker.pkg.github.com/nextools/images/chromium:rc"
+DOCKER_NAMESPACE="nextools"
+
 get-version:
 	@docker pull ubuntu:bionic > /dev/null 2>&1
 	@docker run --rm \
@@ -9,10 +12,11 @@ get-version:
 		sh -c "apt-get update --quiet=2 && apt-cache policy chromium-browser | sed --regexp-extended --quiet 's/.*Candidate: ([0-9.]+)-.+/\1/p'"
 
 build:
-	@docker build --tag chromium --build-arg VERSION=$(version) $(CURRENT_DIR)
+	@docker buildx build --push --platform linux/arm64,linux/amd64 --tag $(IMAGE_NAME) --build-arg VERSION=$(version) $(CURRENT_DIR)
+	@echo $(IMAGE_NAME)
 
 test:
-	@docker run --detach --publish 9222:9222 --name chromium chromium
+	@docker run --detach --publish 9222:9222 --name chromium $(IMAGE_NAME)
 	@timeout 20s sh -c "trap 'docker container rm --force chromium' 0; until curl http://localhost:9222/json/version; do sleep 1; done"
 
 tags:
@@ -23,7 +27,13 @@ tags:
 			tag=latest; \
 		fi; \
 		echo $$tag; \
-		docker tag chromium docker.pkg.github.com/nextools/images/chromium:$$tag; \
-		docker tag chromium nextools/chromium:$$tag; \
+		docker buildx imagetools create $(IMAGE_NAME) --tag docker.pkg.github.com/nextools/images/chromium:$$tag; \
+		chmod +r ${HOME}/.docker/config.json; \
+		docker container run --rm --net host \
+			-u "$(id -u):$(id -g)" -e HOME -v ${HOME}:${HOME} \
+			-v /etc/docker/certs.d:/etc/docker/certs.d:ro \
+			regclient/regctl:latest image copy $(IMAGE_NAME) ${DOCKER_NAMESPACE}/chromium:$$tag; \
 		git tag --force chromium@$$tag; \
 	done
+
+

--- a/firefox/Makefile
+++ b/firefox/Makefile
@@ -1,6 +1,8 @@
 .PHONY: get-version build test tags
 
 CURRENT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+IMAGE_NAME="docker.pkg.github.com/nextools/images/firefox:rc"
+DOCKER_NAMESPACE="nextools"
 
 get-version:
 	@docker pull ubuntu:bionic > /dev/null 2>&1
@@ -10,17 +12,21 @@ get-version:
 
 build:
 	@_version=`echo $(version) | sed --regexp-extended s/a/~a/`
-	@docker build --tag firefox --build-arg VERSION=$$_version $(CURRENT_DIR)
+	@docker buildx build --push --platform linux/arm64,linux/amd64 --tag $(IMAGE_NAME) --build-arg VERSION=$$_version $(CURRENT_DIR)
+	@echo $(IMAGE_NAME)
 
 test:
-	@docker run --detach --publish 9222:9222 --name firefox firefox
+	@docker run --detach --publish 9222:9222 --name firefox $(IMAGE_NAME)
 	@timeout 20s sh -c "trap 'docker container rm --force firefox' 0; until curl http://localhost:9222/json/version; do sleep 1; done"
 
 tags:
 	@for tag in $(version) latest; do \
 		echo $$tag; \
-		docker tag firefox docker.pkg.github.com/nextools/images/firefox:$$tag; \
-		docker tag firefox nextools/firefox:$$tag; \
+		docker buildx imagetools create $(IMAGE_NAME) --tag docker.pkg.github.com/nextools/images/firefox:$$tag; \
+		chmod +r ${HOME}/.docker/config.json; \
+		docker container run --rm --net host \
+			-u "$(id -u):$(id -g)" -e HOME -v ${HOME}:${HOME} \
+			-v /etc/docker/certs.d:/etc/docker/certs.d:ro \
+			regclient/regctl:latest image copy $(IMAGE_NAME) ${DOCKER_NAMESPACE}/firefox:$$tag; \
 		git tag --force firefox@$$tag >/dev/null 2>&1; \
 	done
-


### PR DESCRIPTION
Hey it's me again,

I've finally figured out how to add the multi-platform support with very minor changes to the repository's structure and outputs

### The new method:
- Build and push a multiplatform image to github packages, since docker can't deal with multi-platform images locally.
- Pull the image for whatever platform the Github action is running on (most likely `amd64` i assume) and testing it.
- If no failures occur so far, it will tag it the same way as before on Github packages registry, then it will copy it and push it to docker hub as well.

everything else is relatively untouched.

**NOTE:** This requires extra privileges than `GITHUB_TOKEN` could provide, therefore i believe you need a personal access token of some sort to be added to this repository as a secret under the name `DOCKER_DEPLOYER` (we can change the name if you want, that's no issue) so that this action will be able to tag images remotely on Github Packages registry formerly known as Github docker registry

Perhaps I'm wrong and it will work just fine with `GITHUB_TOKEN`, but it failed for me every single time I've used it.

I've tested this in my own repository and can confirm it works. there may be authentication issues related to the GITHUB_TOKEN but I've stated above in the note how I've handled that.

Cheers!